### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,14 +7,7 @@ approvers:
   - sids-b
   - ugvddm
 reviewers:
-  - chendave
-  - fisherxu
-  - jaypume
   - JimmyYang20
-  - kevin-wangzefeng
   - khalid-davis
-  - llhuii
-  - sids-b
   - TymonXie
-  - ugvddm
 

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -2,9 +2,6 @@ approvers:
   - jaypume
   - llhuii
 reviewers:
-  - jaypume
   - JimmyYang20
   - khalid-davis
-  - llhuii
   - TymonXie
-  - ugvddm

--- a/examples/OWNERS
+++ b/examples/OWNERS
@@ -1,10 +1,6 @@
 approvers:
-  - llhuii
   - jaypume
 reviewers:
-  - jaypume
   - JimmyYang20
   - khalid-davis
-  - llhuii
   - TymonXie
-  - ugvddm

--- a/lib/OWNERS
+++ b/lib/OWNERS
@@ -3,8 +3,5 @@ approvers:
   - khalid-davis
 reviewers:
   - JimmyYang20
-  - TymonXie
-  - jaypume
-  - khalid-davis
   - llhuii
-  - ugvddm
+  - TymonXie

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -5,3 +5,4 @@ reviewers:
   - JimmyYang20
   - khalid-davis
   - TymonXie
+

--- a/pkg/globalmanager/OWNERS
+++ b/pkg/globalmanager/OWNERS
@@ -5,6 +5,3 @@ reviewers:
   - jaypume
   - JimmyYang20
   - khalid-davis
-  - llhuii
-  - TymonXie
-  - ugvddm

--- a/pkg/localcontroller/OWNERS
+++ b/pkg/localcontroller/OWNERS
@@ -3,8 +3,5 @@ approvers:
   - llhuii
 reviewers:
   - jaypume
-  - JimmyYang20
   - khalid-davis
-  - llhuii
   - TymonXie
-  - ugvddm

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -5,5 +5,3 @@ reviewers:
   - TymonXie
   - jaypume
   - khalid-davis
-  - llhuii
-  - ugvddm


### PR DESCRIPTION
From https://git.k8s.io/community/contributors/guide/owners.md,
the approvers should be not in the reviewers section.

So this updates our OWNERS.