### PR TITLE
Fall back to default volume when mounting '/'

### DIFF
--- a/pkg/globalmanager/storage_initializer_injector.go
+++ b/pkg/globalmanager/storage_initializer_injector.go
@@ -39,6 +39,8 @@ const (
 
 	indirectURLMark    = "@"
 	indirectURLMarkEnv = "INDIRECT_URL_MARK"
+
+	defaultVolumeName = "sedna-default-volume-name"
 )
 
 var supportStorageInitializerURLSchemes = [...]string{
@@ -206,11 +208,12 @@ func injectHostPathMount(pod *v1.Pod, workerParam *WorkerParam) {
 			if m.HostPath == "" {
 				continue
 			}
+
 			volumeName := ConvertK8SValidName(m.HostPath)
 
-			if volumeName == "" {
-				klog.Warningf("failed to convert volume name from the url and skipped: %s", m.URL)
-				continue
+			if len(volumeName) == 0 {
+				volumeName = defaultVolumeName
+				klog.Warningf("failed to get name from url(%s), fallback to default name(%s)", m.URL, volumeName)
 			}
 
 			if _, ok := uniqVolumeName[volumeName]; !ok {


### PR DESCRIPTION
Fix the case user creates a dataset/model CR with url like '/model.pb',
in present GM will attach its parent directory '/' into the worker,
the volume name generated from '/' will be empty.