### PR TITLE
Push images automatically when a new release is created

### DIFF
--- a/.github/workflows/image-publish.yaml
+++ b/.github/workflows/image-publish.yaml
@@ -1,0 +1,32 @@
+# refers:
+# https://docs.docker.com/ci-cd/github-actions/
+# https://docs.github.com/cn/actions/guides/publishing-docker-images
+name: Publish Docker Images
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push images to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: ./src/github.com/${{ github.repository }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Run push images
+        run: |
+          # ${GITHUB_ACTOR} => kubeedge
+          # ${GITHUB_REF} => refs/tags/v0.0.1
+          # see https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+          make push-all IMAGE_REPO=${GITHUB_ACTOR} IMAGE_TAG=${GITHUB_REF#refs/*/}
+        working-directory: ./src/github.com/${{ github.repository }}


### PR DESCRIPTION
fix #90 

This commit creates a github action which does the following steps:
1. login docker hub.
2. checkout the project, and run `make push-all`.

And when we create a new release this action will be triggered to run.

Tested in my personal fork, see https://github.com/llhuii/sedna/actions/runs/1126507005.