### PR TITLE
Fix IMAGE_REPO in github image-publish action

### DIFF
--- a/.github/workflows/image-publish.yaml
+++ b/.github/workflows/image-publish.yaml
@@ -25,8 +25,9 @@ jobs:
 
       - name: Run push images
         run: |
-          # ${GITHUB_ACTOR} => kubeedge
+          # ${GITHUB_REPOSITORY} => kubeedge/sedna
           # ${GITHUB_REF} => refs/tags/v0.0.1
+          # IMAGE_REPO=kubeedge IMAGE_TAG=v0.0.1
           # see https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
-          make push-all IMAGE_REPO=${GITHUB_ACTOR} IMAGE_TAG=${GITHUB_REF#refs/*/}
+          make push-all IMAGE_REPO=${GITHUB_REPOSITORY%/*} IMAGE_TAG=${GITHUB_REF#refs/*/}
         working-directory: ./src/github.com/${{ github.repository }}


### PR DESCRIPTION
From https://github.com/kubeedge/sedna/actions/runs/1134112088, GITHUB_ACTOR is the github user who has created the release, this is unexpected for the right image repo name `kubeedge`.
So using the env 'GITHUB_REPOSITORY' whose value is `kubeedge/sedna`.