### PR TITLE
Increase GM memory limit from 128Mi to 256Mi

### DIFF
--- a/scripts/installation/install.sh
+++ b/scripts/installation/install.sh
@@ -249,7 +249,7 @@ spec:
             memory: 32Mi
             cpu: 100m
           limits:
-            memory: 128Mi
+            memory: 256Mi
       volumes:
         - name: gm-config
           configMap:


### PR DESCRIPTION
In some environment, GM will use about 150M memory.
This avoids GM to be OOM killed temporarily.

TBD: Dive to analyze GM memory usage, which should be less than 128Mi.