### PR TITLE
GM: remove externalIPs when creating k8s service

### DIFF
--- a/pkg/globalmanager/runtime/worker.go
+++ b/pkg/globalmanager/runtime/worker.go
@@ -92,10 +92,7 @@ func CreateKubernetesService(kubeClient kubernetes.Interface, object CommonInter
 		},
 		Spec: v1.ServiceSpec{
 			Selector: generateLabels(object, workerType),
-			ExternalIPs: []string{
-				inputIP,
-			},
-			Type: v1.ServiceTypeNodePort,
+			Type:     v1.ServiceTypeNodePort,
 			Ports: []v1.ServicePort{
 				{
 					Port:       inputPort,


### PR DESCRIPTION
The 'externalIPs' is unnecessary, and in some environment can result in the correspoing
kubelet can't reach api server, and then node unreachable status.

Signed-off-by: llhuii <liulinghui@huawei.com>