### PR TITLE
Fix the wrong uvicorn version in sedna lib

### DIFF
--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -11,4 +11,4 @@ joblib~=1.0.1  # BSD
 pandas~=1.1.5  # BSD
 six~=1.15.0  # MIT
 minio~=7.0.3  # Apache-2.0
-uvicorn>=0.14.0  # BSD
+uvicorn~=0.14.0  # BSD


### PR DESCRIPTION
Signed-off-by: Jie Pu <i@jaypu.com>