### PR TITLE
examples: fix the image name prefix

### DIFF
--- a/examples/build_image.sh
+++ b/examples/build_image.sh
@@ -100,5 +100,5 @@ dockerfiles=($(echo "${dockerfiles[@]}" | tr ' ' '\n' | sort -u))
 for dockerfile in ${dockerfiles[@]}; do
    echo "Building $dockerfile" 
    example_name=${dockerfile/.Dockerfile}
-   docker build -f $dockerfile -t ${IMAGE_REPO}/${example_name}:${IMAGE_TAG} --label sedna=examples ..
+   docker build -f $dockerfile -t ${EXAMPLE_REPO_PREFIX}${example_name}:${IMAGE_TAG} --label sedna=examples ..
 done


### PR DESCRIPTION
fix the missing `sedna-example-` prefix image name bug introduced by #214, else our push script would [report something](https://github.com/kubeedge/sedna/actions/runs/1416003481):
```
2021-11-03T10:09:09.0703862Z denied: requested access to the resource is denied
2021-11-03T10:09:09.0724598Z failed to docker push kubeedge/federated-learning-surface-defect-detection-aggregation:v0.4.3
2021-11-03T10:09:09.1243181Z The push refers to repository [docker.io/kubeedge/federated-learning-mistnet-yolo-client]
```