### PR TITLE
Upgrade golang from 1.14 to 1.16

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
 
       - uses: actions/cache@v2
         with:
@@ -78,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
 
       - uses: actions/cache@v2
         with:
@@ -102,7 +102,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
 
       - uses: actions/cache@v2
         with:
@@ -138,7 +138,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
 
       - uses: actions/cache@v2
         with:
@@ -159,7 +159,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
 
       - uses: actions/cache@v2
         with:

--- a/build/gm/Dockerfile
+++ b/build/gm/Dockerfile
@@ -14,7 +14,7 @@
 
 # Add cross buildx improvement
 # _speed_buildx_for_go_
-FROM golang:1.14-alpine3.11 AS builder
+FROM golang:1.16-alpine3.15 AS builder
 LABEL stage=builder
 
 ARG GO_LDFLAGS

--- a/build/lc/Dockerfile
+++ b/build/lc/Dockerfile
@@ -15,7 +15,7 @@
 # Add cross buildx improvement
 # LC has built sqlite3 which requires CGO with CGO_ENABLED=1
 # _speed_buildx_for_cgo_alpine_
-FROM golang:1.14-alpine3.11 AS builder
+FROM golang:1.16-alpine3.15 AS builder
 LABEL stage=builder
 
 ARG GO_LDFLAGS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeedge/sedna
 
-go 1.14
+go 1.16
 
 require (
 	github.com/emicklei/go-restful/v3 v3.4.0


### PR DESCRIPTION
The CI checker [`E2e test`](https://github.com/kubeedge/sedna/runs/4453911167?check_suite_focus=true) depends the lastest kubeedge which requires golang `1.16`, here we upgrade our golang verison to `1.16`.