### PR TITLE
Fix ci e2e running failed issue.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -111,12 +111,11 @@ jobs:
 
       - name: Install dependences
         run: |
-          # since this ubuntu-latest os has already kind/kubectl/jq(see https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md),
-          # this just makes it sure
-          type kind || {
-            sudo apt-get install -y jq
-            go get sigs.k8s.io/kind@$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)
-          }
+          # since this ubuntu-latest os has already kind/kubectl/jq(see https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md),
+          # but kind v0.19.0 has different api with v0.18.0, so here to reinstall kind v0.18.0
+          sudo apt-get install -y jq
+          go get sigs.k8s.io/kind@$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/97518847 | jq -r .tag_name)
+          kind version
           type kubectl || {
             curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
             chmod +x ./kubectl


### PR DESCRIPTION
Fix ci e2e running failed issue.


The github action runner image `ubuntu22.04` has upgrade kind version from v0.18.0 to v0.19.0:
https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
![image](https://github.com/kubeedge/sedna/assets/1785240/4652c914-a9bd-4dfd-8f75-c93e3a584b7b)

but this will lead  sedna `all-in-one.sh` running failed in github action, for the  incompatible interface. 

![image](https://github.com/kubeedge/sedna/assets/1785240/07f4db8a-1d60-43d3-b477-3f7f6218b572)


