### PR TITLE
Update uvicorn's version in `lib/requirements.txt` to fix installation issue with latest `pip`

### DIFF
--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -11,5 +11,5 @@ joblib~=1.2.0  # BSD
 pandas  # BSD
 six~=1.15.0  # MIT
 minio~=7.0.3  # Apache-2.0
-uvicorn~=0.14.0  # BSD
+uvicorn~=0.15.0  # BSD
 pycocotools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/sedna/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The latest `pip` has deprecated certain interface, making sedna's dependency `uvicorn~=0.14.0` cannot be installed.

This PR change `uvicorn`'s version from `0.14.0` to `0.15.0` to fix this problem.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #440 
