### PR TITLE
fix: propagate configured HTTP request timeout

### DIFF
--- a/lib/sedna/service/client.py
+++ b/lib/sedna/service/client.py
@@ -45,7 +45,8 @@ def http_request(
     _maxTimeout = timeout if timeout else 300
     _method = "GET" if not method else method
     try:
-        response = requests.request(method=_method, url=url, **kwargs)
+        response = requests.request(
+            method=_method, url=url, timeout=_maxTimeout, **kwargs)
         if response.status_code == 200:
             if no_decode:
                 return response

--- a/lib/tests/test_service_client.py
+++ b/lib/tests/test_service_client.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from sedna.service.client import http_request
+
+
+class HTTPRequestTest(unittest.TestCase):
+
+    @patch("sedna.service.client.requests.request")
+    def test_forwards_explicit_timeout(self, request):
+        response = Mock(status_code=200)
+        request.return_value = response
+
+        self.assertIs(http_request(
+            "http://example.test", timeout=7, no_decode=True), response)
+
+        request.assert_called_once_with(
+            method="GET", url="http://example.test", timeout=7)
+
+    @patch("sedna.service.client.requests.request")
+    def test_forwards_default_timeout(self, request):
+        response = Mock(status_code=200)
+        request.return_value = response
+
+        self.assertIs(http_request(
+            "http://example.test", no_decode=True), response)
+
+        request.assert_called_once_with(
+            method="GET", url="http://example.test", timeout=300)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Forwards the timeout already computed by `http_request()` to `requests.request()`. Explicit timeouts now take effect, while the existing 300-second default and retry behavior remain unchanged.

**Which issue(s) this PR fixes**:

Fixes #488

**Validation**:

Added `lib/tests/test_service_client.py` with focused cases proving that both an explicit timeout and the 300-second default are forwarded to `requests.request()`.

```bash
PYTHONPATH=lib python -m unittest discover -s lib/tests -v
```

Result: 2 tests passed. Python compilation and `git diff --check` also pass.
