### PR TITLE
fix: avoid eager estimator fallback lookup

### DIFF
--- a/lib/sedna/backend/base.py
+++ b/lib/sedna/backend/base.py
@@ -57,7 +57,9 @@ class BackendBase:
         if callable(self.estimator):
             varkw = self.parse_kwargs(self.estimator, **kwargs)
             self.estimator = self.estimator(**varkw)
-        fit_method = getattr(self.estimator, "fit", self.estimator.train)
+        fit_method = getattr(self.estimator, "fit", None)
+        if fit_method is None:
+            fit_method = self.estimator.train
         varkw = self.parse_kwargs(fit_method, **kwargs)
         return fit_method(*args, **varkw)
 
@@ -66,7 +68,9 @@ class BackendBase:
         if callable(self.estimator):
             varkw = self.parse_kwargs(self.estimator, **kwargs)
             self.estimator = self.estimator(**varkw)
-        fit_method = getattr(self.estimator, "fit", self.estimator.update)
+        fit_method = getattr(self.estimator, "fit", None)
+        if fit_method is None:
+            fit_method = self.estimator.update
         varkw = self.parse_kwargs(fit_method, **kwargs)
         return fit_method(*args, **varkw)
 

--- a/lib/tests/test_backend_base.py
+++ b/lib/tests/test_backend_base.py
@@ -1,0 +1,44 @@
+import unittest
+
+from sedna.backend.base import BackendBase
+
+
+class FitOnlyEstimator:
+
+    def fit(self, value):
+        return "fit", value
+
+
+class TrainOnlyEstimator:
+
+    def train(self, value):
+        return "train", value
+
+
+class UpdateOnlyEstimator:
+
+    def update(self, value):
+        return "update", value
+
+
+class BackendBaseFallbackTest(unittest.TestCase):
+
+    def test_train_uses_fit_without_eager_train_lookup(self):
+        backend = BackendBase(FitOnlyEstimator())
+        self.assertEqual(backend.train("sample"), ("fit", "sample"))
+
+    def test_train_falls_back_to_train(self):
+        backend = BackendBase(TrainOnlyEstimator())
+        self.assertEqual(backend.train("sample"), ("train", "sample"))
+
+    def test_update_uses_fit_without_eager_update_lookup(self):
+        backend = BackendBase(FitOnlyEstimator())
+        self.assertEqual(backend.update("sample"), ("fit", "sample"))
+
+    def test_update_falls_back_to_update(self):
+        backend = BackendBase(UpdateOnlyEstimator())
+        self.assertEqual(backend.update("sample"), ("update", "sample"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Selects `fit()` or the fallback method lazily in `BackendBase.train()` and `BackendBase.update()`. Fit-only, train-only, and update-only estimators no longer fail during eager fallback attribute lookup.

**Which issue(s) this PR fixes**:

Fixes #490

**Validation**:

Added `lib/tests/test_backend_base.py` with focused cases covering:

- `train()` with a fit-only estimator;
- `train()` falling back to `train()`;
- `update()` with a fit-only estimator;
- `update()` falling back to `update()`.

```bash
PYTHONPATH=lib python -m unittest discover -s lib/tests -v
```

Result: 4 tests passed. Python compilation and `git diff --check` also pass.
